### PR TITLE
Fix argument formatting for dotnet list command

### DIFF
--- a/NativeAOTDependencyHelper.Core/DotnetToolingInterop.cs
+++ b/NativeAOTDependencyHelper.Core/DotnetToolingInterop.cs
@@ -40,7 +40,7 @@ public class DotnetToolingInterop(ILogger _logger)
         {
             Process process = new();
             process.StartInfo.FileName = "dotnet.exe";
-            process.StartInfo.Arguments = $"list {solutionpath} package --include-transitive --format json";
+            process.StartInfo.Arguments = $"list \"{solutionpath}\" package --include-transitive --format json";
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.UseShellExecute = false;
             process.StartInfo.CreateNoWindow = true;


### PR DESCRIPTION
Fixed an issue where `dotnet list package` returned help text instead of JSON output. The problem was caused by missing quotes around the solution/project path when passing arguments to the `dotnet` CLI. Paths containing spaces were not handled correctly.