### PR TITLE
Update XAML Styler to 3.2501.8

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "xamlstyler.console": {
-      "version": "3.2206.4",
+      "version": "3.2501.8",
       "commands": [
         "xstyler"
       ]


### PR DESCRIPTION
Fixes #15 

Updating XAML Styler to latest version which should be built/run against newer .NET version on CI VMs.